### PR TITLE
Update KeyItem.java

### DIFF
--- a/src/main/java/mod/gottsch/forge/treasure2/core/item/KeyItem.java
+++ b/src/main/java/mod/gottsch/forge/treasure2/core/item/KeyItem.java
@@ -17,6 +17,14 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Treasure2.  If not, see <http://www.gnu.org/licenses/lgpl>.
  */
+/*
+ * Error NTB Tag = Null
+ * ArrayIndexOutOfBoundsException:
+ * NullPointerException:
+ * Fix - Patch
+ */
+
+
 package mod.gottsch.forge.treasure2.core.item;
 
 import mod.gottsch.forge.gottschcore.enums.IRarity;
@@ -28,7 +36,6 @@ import mod.gottsch.forge.treasure2.core.block.ITreasureChestBlockProxy;
 import mod.gottsch.forge.treasure2.core.block.entity.AbstractTreasureChestBlockEntity;
 import mod.gottsch.forge.treasure2.core.block.entity.ITreasureChestBlockEntity;
 import mod.gottsch.forge.treasure2.core.capability.DurabilityCapability;
-import mod.gottsch.forge.treasure2.core.capability.DurabilityHandler;
 import mod.gottsch.forge.treasure2.core.capability.IDurabilityHandler;
 import mod.gottsch.forge.treasure2.core.capability.TreasureCapabilities;
 import mod.gottsch.forge.treasure2.core.config.Config;
@@ -66,585 +73,420 @@ import static mod.gottsch.forge.treasure2.core.capability.TreasureCapabilities.D
 
 /**
  * 
- * @author Mark Gottschling on Jan 11, 2018
+ * KeyItem with patch to avoid NBT corruption crashes.
  *
  */
 public class KeyItem extends Item implements IKeyEffects {
-	public static final int DEFAULT_MAX_USES = 25;
-	public static final String DURABILITY_TAG = "treasure2:durability";
+    public static final int DEFAULT_MAX_USES = 25;
+    public static final String DURABILITY_TAG = "treasure2:durability";
 
-	/*
-	 * The category that the key belongs to
-	 */
-	private KeyLockCategory category;
+    private KeyLockCategory category;
+    private boolean craftable;
+    private boolean breakable;
+    private double successProbability;
 
-	/*
-	 * Is the key craftable
-	 */
-	private boolean craftable;
+    private List<Predicate<LockItem>> fitsLock;
+    private List<Predicate<LockItem>> breaksLock;
 
-	/*
-	 * Can the key break attempting to unlock a lock
-	 */
-	private boolean breakable;
+    private int durability = Integer.MIN_VALUE;
 
-	/*
-	 * Can the key take damage and lose durability
-	 */
-//	private boolean damageable;
-
-	/*
-	 * The probability of a successful unlocking
-	 */
-	private double successProbability;
-
-	/*
-	 * A list of predicates that determine if a key fits into a lock.
-	 */
-	private List<Predicate<LockItem >> fitsLock;
-	
-	/*
-	 * A list of predicates that determine if a key will break a lock.
-	 */
-	private List<Predicate<LockItem >> breaksLock;
-
-	/*
-	 * The default (dynamic) durability of the item.
-	 * This value should be changed during LevelEvent.load event to equal
-	 * the value specified in the config.
-	 */
-	private int durability = Integer.MIN_VALUE;
-
-	/**
-	 * 
-	 * @param properties
-	 */
-	public KeyItem(Item.Properties properties) {
-		this(properties, DEFAULT_MAX_USES);
-	}
-
-	/**
-	 *
-	 * @param properties
-	 * @param durability
-	 */
-	public KeyItem(Item.Properties properties, int durability) {
-		super(properties.defaultDurability(durability));//.defaultDurability(DEFAULT_MAX_USES));
-		setCategory(KeyLockCategory.ELEMENTAL);
-		setBreakable(true);
-		setCraftable(false);
-		setSuccessProbability(90D);
-		setDurability(durability);
-	}
-
-	@Override
-	public ICapabilityProvider initCapabilities(ItemStack stack, CompoundTag nbt) {
-		DurabilityCapability provider = new DurabilityCapability();
-		LazyOptional<IDurabilityHandler> cap = provider.getCapability(TreasureCapabilities.DURABILITY, null);
-		cap.ifPresent(c -> {
-			// to be overridden during LevelEvent.load event
-			c.setDefaultDurability(this.getDurability());
-		});
-		return provider;
-	}
-
-	/**
-	 * NOTE getShareTag() and readShareTag() are required to sync item capabilities server -> client. I needed this when holding charms in hands and then swapping hands
-	 * or having the client update when the Anvil GUI is open.
-	 *
-	 * 1/25/2024 in 1.19.3+ these methods are not needed and in fact caused the mod
-	 * not to work properly.
-	 */
-	@Override
-	public CompoundTag getShareTag(ItemStack stack) {
-		super.getShareTag(stack);
-
-		CompoundTag capabilityTag = null;
-		IDurabilityHandler handler = stack.getCapability(DURABILITY).map(h -> h).orElse(null);
-		if (handler != null) {
-			capabilityTag = handler.save();
-		}
-		CompoundTag stackTag = stack.getOrCreateTag();
-		// NOTE must ensure to add the capability tag to the original stack tag.
-		if (capabilityTag != null) {
-			stackTag.put(DURABILITY_TAG, capabilityTag);
-		}
-		return stackTag;
-	}
-
-	@Override
-	public void readShareTag(ItemStack stack, @Nullable CompoundTag tag) {
-		super.readShareTag(stack, tag);
-
-		if (tag.contains(DURABILITY_TAG)) {
-			IDurabilityHandler handler = stack.getCapability(DURABILITY).map(h -> h).orElse(null);
-			if (handler != null) {
-				handler.load(tag.get(DURABILITY_TAG));
-			}
-		}
-	}
-
-	/**
-	 * Format:
-	 * 		Item Name (vanilla minecraft)
-	 * 		Rarity: [...]  [color = Gold] 
-	 * 		Category:  [...] [color = Gold]
-	 * 		Uses Remaining: [n]
-	 * 		Max Uses: [n] [color = Gold]
-	 * 		Breakable: [Yes | No] [color = Dark Red | Green]
-	 * 		Craftable: [Yes | No] [color = Green | Dark Red]
-	 * 	 	Damageable: [Yes | No] [color = Dark Red | Green]
-	 */
-	@Override
-	public void appendHoverText(ItemStack stack, Level worldIn, List<Component> tooltip, TooltipFlag flag) {
-//		Treasure.LOGGER.debug("appendHoverText damage -> {}", stack.getDamageValue());
-		// TODO this optional probably can be better written
-		if (stack.getCapability(DURABILITY).isPresent()) {
-			stack.getCapability(DURABILITY).ifPresent(cap -> {
-				if (cap.isInfinite()) {
-					tooltip.add(Component.translatable(LangUtil.tooltip("cap.durability.amount.infinite")));
-				}
-				else {
-					tooltip.add(Component.translatable(LangUtil.tooltip("cap.durability.amount"), cap.durability(stack.getItem()) - stack.getDamageValue(), cap.durability(stack.getItem())));
-				}
-			});
-		}
-		else {
-			tooltip.add(Component.translatable(LangUtil.tooltip("cap.durability.amount"), /*stack.getMaxDamage() - stack.getDamageValue()*/"whaat", getDurability()));
-		}
-		
-		tooltip.add(Component.translatable(LangUtil.tooltip("key_lock.rarity"), ChatFormatting.BLUE + Component.translatable(getRarity().getValue().toLowerCase()).getString().toUpperCase() ));
-		tooltip.add(Component.translatable(LangUtil.tooltip("key_lock.category"), ChatFormatting.GOLD + Component.translatable(getCategory().toString().toLowerCase()).getString().toUpperCase()));
-
-		LangUtil.appendAdvancedHoverText(tooltip, tt -> {
-			
-			// is breakable tooltip
-			MutableComponent breakable = null;
-			if (isBreakable()) {
-				breakable = Component.translatable(LangUtil.tooltip("boolean.yes")).withStyle(ChatFormatting.DARK_RED);
-			}
-			else {
-				breakable = Component.translatable(LangUtil.tooltip("boolean.no")).withStyle(ChatFormatting.GREEN);
-			}
-			tooltip.add(
-					Component.translatable(LangUtil.tooltip("key_lock.breakable"), breakable));
-
-			MutableComponent craftable = null;
-			if (isCraftable()) {
-				craftable = Component.translatable(LangUtil.tooltip("boolean.yes")).withStyle(ChatFormatting.GREEN);
-			}
-			else {
-				craftable = Component.translatable(LangUtil.tooltip("boolean.no")).withStyle(ChatFormatting.DARK_RED);
-			}
-			tooltip.add(Component.translatable(LangUtil.tooltip("key_lock.craftable"), craftable));
-		
-			appendHoverSpecials(stack, worldIn, tooltip, flag);
-			appendHoverExtras(stack, worldIn, tooltip, flag);
-		});
-		// NOTE adding curse here makes it unremovable.
-		// TODO adding curse AFTER the HOLD lambda only adds it once to the tooltip.
-		// if added BEFORE, like in initCapabilities(), it is added twice to the tooltip
-		// TEMP fix for double Curses displayed
-		appendCurse(stack, tooltip);
-	}
-
-	public void appendCurse(ItemStack stack, List<Component> tooltip) {
-
-	}
-
-	public  void appendHoverSpecials(ItemStack stack, Level worldIn, List<Component> tooltip, TooltipFlag flag) {
-	}
-	
-	public void appendHoverExtras(ItemStack stack, Level worldIn, List<Component> tooltip, TooltipFlag flag) {
-	}
-
-	/**
-	 * Queries the percentage of the 'Durability' bar that should be drawn.
-	 *
-	 * @param stack The current ItemStack
-	 * @return 
-	 * @return 0.0 for 100% (no damage / full bar), 1.0 for 0% (fully damaged / empty bar)
-	 */
-	@Override
-	public int getBarWidth(ItemStack stack) {
-		return stack.getCapability(DURABILITY).map(handler -> {
-			return Math.round(13.0F - (float)stack.getDamageValue() * 13.0F / (float)handler.durability(stack.getItem()));
-		}).orElse(Math.round(13.0F - (float)stack.getDamageValue() * 13.0F / (float)this.getDurability()));
-	}
-
-	@Override
-	public int getBarColor(ItemStack stack) {
-		float stackMaxDamage = stack.getCapability(DURABILITY).map(handler -> handler.durability(stack.getItem())).orElse(this.getDurability());
-		//this.getMaxDamage(stack);
-		float f = Math.max(0.0F, (stackMaxDamage - (float)stack.getDamageValue()) / stackMaxDamage);
-		return Mth.hsvToRgb(f / 3.0F, 1.0F, 1.0F);
-	}
-
-	/**
-	 * 
-	 */
-	@Override
-	public boolean isValidRepairItem(ItemStack itemToRepair, ItemStack resourceItem) {
-		return resourceItem.getItem() == this || super.isValidRepairItem(itemToRepair, resourceItem);
-	}
-
-	@Override
-	public InteractionResult useOn(UseOnContext context) {
-		// exit if on the client
-		if (WorldInfo.isClientSide(context.getLevel())) {			
-			return InteractionResult.FAIL;
-		}
-
-		BlockPos chestPos = context.getClickedPos();
-		BlockState state = context.getLevel().getBlockState(chestPos);
-		Block block = state.getBlock();
-
-		// test if the block is a chest proxy (ex. multiple block chests like Wither Chest)
-		if (block instanceof ITreasureChestBlockProxy) {
-			chestPos = ((ITreasureChestBlockProxy)block).getChestPos(chestPos);
-			state = context.getLevel().getBlockState(chestPos);
-			block = state.getBlock();
-		}
-
-		// determine if block at pos is a treasure chest
-		if (block instanceof AbstractTreasureChestBlock) {
-			// get the tile entity
-			BlockEntity blockEntity = context.getLevel().getBlockEntity(chestPos);
-			if (blockEntity == null || !(blockEntity instanceof ITreasureChestBlockEntity)) {
-				Treasure.LOGGER.warn("null or incorrect blockEntity");
-				return InteractionResult.FAIL;
-			}
-			ITreasureChestBlockEntity chestBlockEntity = (ITreasureChestBlockEntity)blockEntity;
-
-			// determine if chest is locked
-			if (!chestBlockEntity.hasLocks()) {
-				return InteractionResult.SUCCESS;
-			}
-
-			try {
-				ItemStack heldItemStack = context.getPlayer().getItemInHand(context.getHand());	
-				boolean breakKey = true;
-				boolean fitsLock = false;
-				LockState lockState = null;
-				boolean isKeyBroken = false;
-				// check if this key is one that opens a lock (only first lock that key fits is unlocked).
-				lockState = fitsFirstLock(chestBlockEntity.getLockStates());
-				if (lockState != null) {
-					fitsLock = true;
-				}
-
-				if (fitsLock) {
-					if (unlock(lockState.getLock())) {
-						// unlock the lock
-						doUnlock(context, chestBlockEntity, lockState);
-
-						if (!state.getValue(AbstractTreasureChestBlock.DISCOVERED)) {
-							chestBlockEntity = ((AbstractTreasureChestBlock) block).discovered((AbstractTreasureChestBlockEntity) chestBlockEntity, state, context.getLevel(), chestPos, context.getPlayer());
-						}
-						
-						// update the client
-						chestBlockEntity.sendUpdates();
-
-						// don't break the key
-						breakKey = false;
-					}
-				}
-
-				IDurabilityHandler cap = heldItemStack.getCapability(DURABILITY).orElseThrow(IllegalStateException::new);
-				
-				// check key's breakability
-				if (breakKey) {
-					Treasure.LOGGER.debug("breakKey -> {}", breakKey);
-					if (!context.getPlayer().isCreative() && (isBreakable() || anyLockBreaksKey(chestBlockEntity.getLockStates(), this)) && Config.SERVER.keysAndLocks.enableKeyBreaks.get()) {
-						Treasure.LOGGER.debug("is breakable -> {}", isBreakable());
-						// this damage block is considering if a key has been merged with another key.
-						// it is only 'breaking' 1 key's worth of damage
-						// ex k1(1/10d) + k2(0/10d) = k3(1/20d), only apply 9 damage
-						// so k3 = (10/20d) ie 1 key's worth damage was applied.
-//						8/20/2024:
-//						int durability = cap.durability(heldItemStack.getItem());
-
-						// get the default durability of of the item
-						int durability = getDurability();
-						int damage = heldItemStack.getDamageValue() + (durability - (heldItemStack.getDamageValue() % durability));
-
-						heldItemStack.setDamageValue(damage);
-						Treasure.LOGGER.debug("damaging key -> {}", heldItemStack.getDamageValue());
-						if (heldItemStack.getDamageValue() >= cap.durability(heldItemStack.getItem())) {
-							// break key;
-							heldItemStack.shrink(1);
-						}
-
-						// do effects
-						doKeyBreakEffects(context.getLevel(), context.getPlayer(), chestPos);
-
-						// flag the key as broken
-						isKeyBroken = true;
-					}
-					else if (!fitsLock) {
-						doKeyNotFitEffects(context.getLevel(), context.getPlayer(), chestPos);
-					}
-					else {
-						doKeyUnableToUnlockEffects(context.getLevel(), context.getPlayer(), chestPos);
-					}						
-				}
-
-				// user attempted to use key - increment the damage
-				if (!context.getPlayer().isCreative() && isDamageable(heldItemStack) && !isKeyBroken) {
-					heldItemStack.setDamageValue(heldItemStack.getDamageValue() + 1);
-					Treasure.LOGGER.debug("damaging key -> {}", heldItemStack.getDamageValue());
-
-					if (heldItemStack.getDamageValue() >= cap.durability(heldItemStack.getItem())) {
-						heldItemStack.shrink(1);
-					}
-				}
-			} catch (Exception e) {
-				Treasure.LOGGER.error("error: ", e);
-			}			
-		}		
-
-		return super.useOn(context);
-	}
-
-	/**
-	 * 
-	 * @param context
-	 * @param chestTileEntity
-	 * @param lockState
-	 */
-	public void doUnlock(UseOnContext context, ITreasureChestBlockEntity chestTileEntity, LockState lockState) {
-		LockItem lock = lockState.getLock();		
-		lock.doUnlock(context.getLevel(), context.getPlayer(), context.getClickedPos(), lockState);
-
-		if (!breaksLock(lock)) {
-			// spawn the lock
-			lock.dropLock(context.getLevel(), context.getClickedPos());
-		}
-	}
-
-	/**
-	 * This method is a secondary check against a lock item.
-	 * Add predicates to the fistsLock list to overrule LockItem.acceptsKey()
-	 *  if this is a key with special abilities.
-	 * @param lockItem
-	 * @return
-	 */
-	public boolean fitsLock(LockItem lockItem) {
-		if (getFitsLock() == null || getFitsLock().isEmpty()) {
-			return false;
-		}
-		for (Predicate<LockItem> p : this.getFitsLock()) {
-			boolean result = p.test(lockItem);
-			if (!result) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * 
-	 * @param lockStates
-	 * @return
-	 */
-	public LockState  fitsFirstLock(List<LockState> lockStates) {
-		LockState lockState = null;
-		// check if this key is one that opens a lock (only first lock that key fits is unlocked).
-		for (LockState ls : lockStates) {
-			if (ls.getLock() != null) {
-				lockState = ls;
-				if (lockState.getLock().acceptsKey(this) || fitsLock(lockState.getLock())) {
-					return ls;
-				}
-			}
-		}
-		return null; // <-- TODO should return EMPTY_LOCKSTATE
-	}
-
-	/**
-	 * 
-	 * @param lockItem
-	 * @return
-	 */
-	public boolean unlock(LockItem lockItem) {	
-		if (lockItem.acceptsKey(this) || fitsLock(lockItem)) {
-			Treasure.LOGGER.debug("lock -> {} accepts key -> {}", ModUtil.getName(lockItem), ModUtil.getName(this));
-			if (RandomHelper.checkProbability(new Random(), this.getSuccessProbability())) {
-				Treasure.LOGGER.debug("unlock attempt met probability");
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * 
-	 * @param lockItem
-	 * @return
-	 */
-    public boolean breaksLock(LockItem lockItem) {
-		if (getBreaksLock() == null || getBreaksLock().isEmpty()) {
-			return false;
-		}
-		for (Predicate<LockItem> p : this.getBreaksLock()) {
-			boolean result = p.test(lockItem);
-			if (!result) {
-				return false;
-			}
-		}
-		return true;
+    public KeyItem(Item.Properties properties) {
+        this(properties, DEFAULT_MAX_USES);
     }
 
-	/**
-	 * 
-	 * @param lockStates
-	 * @param key
-	 * @return
-	 */
-	public boolean anyLockBreaksKey(List<LockState> lockStates, KeyItem key) {
-		for (LockState ls : lockStates) {
-			if (ls.getLock() != null) {
-				if (ls.getLock().breaksKey(key)) {
-					return true;
-				}				
-			}
-		}
-		return false;
-	}
+    public KeyItem(Item.Properties properties, int durability) {
+        super(properties.defaultDurability(durability));
+        setCategory(KeyLockCategory.ELEMENTAL);
+        setBreakable(true);
+        setCraftable(false);
+        setSuccessProbability(90D);
+        setDurability(durability);
+    }
 
-	/**
-	 * @return the rarity
-	 */
-	public IRarity getRarity() {
-		IRarity rarity = KeyLockRegistry.getRarityByKey(this);
-		if (rarity == null) {
-			return Rarity.NONE;
-		}
-		return rarity;
-	}
+    @Override
+    public ICapabilityProvider initCapabilities(ItemStack stack, CompoundTag nbt) {
+        DurabilityCapability provider = new DurabilityCapability();
+        LazyOptional<IDurabilityHandler> cap = provider.getCapability(TreasureCapabilities.DURABILITY, null);
+        cap.ifPresent(c -> {
+            c.setDefaultDurability(this.getDurability());
+        });
+        return provider;
+    }
 
-	/**
-	 * @return the craftable
-	 */
-	public boolean isCraftable() {
-		return craftable;
-	}
+    /**
+     * PATCH: Envuelve en try/catch para evitar ArrayIndexOutOfBounds
+     * si el CompoundTag interno está corrupto.
+     */
+    @Override
+    public CompoundTag getShareTag(ItemStack stack) {
+        try {
+            super.getShareTag(stack);
 
-	/**
-	 * @param craftable the craftable to set
-	 */
-	public KeyItem setCraftable(boolean craftable) {
-		this.craftable = craftable;
-		return this;
-	}
+            CompoundTag capabilityTag = null;
+            IDurabilityHandler handler = stack.getCapability(DURABILITY).map(h -> h).orElse(null);
+            if (handler != null) {
+                capabilityTag = handler.save();
+            }
+            CompoundTag stackTag = stack.getOrCreateTag();
+            if (capabilityTag != null) {
+                stackTag.put(DURABILITY_TAG, capabilityTag);
+            }
+            return stackTag;
+        } catch (Exception e) {
+            Treasure.LOGGER.warn("KeyItem NBT corrupto — eliminando datos inválidos", e);
+            return new CompoundTag(); // devuelvo un tag vacío para evitar crashear
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return "KeyItem [rarity=" + getRarity() + ", craftable=" + craftable + "]";
-	}
+    /**
+     * PATCH: Comprueba si 'tag' es null antes de llamar 'tag.contains(...)'.
+     */
+    @Override
+    public void readShareTag(ItemStack stack, @Nullable CompoundTag tag) {
+        super.readShareTag(stack, tag);
+        if (tag == null) {
+            return; // evita NullPointerException
+        }
 
-	/**
-	 * @return the category
-	 */
-	public KeyLockCategory getCategory() {
-		return category;
-	}
+        if (tag.contains(DURABILITY_TAG)) {
+            IDurabilityHandler handler = stack.getCapability(DURABILITY).map(h -> h).orElse(null);
+            if (handler != null) {
+                handler.load(tag.get(DURABILITY_TAG));
+            }
+        }
+    }
 
-	/**
-	 * @param category the category to set
-	 */
-	public KeyItem setCategory(KeyLockCategory category) {
-		this.category = category;
-		return this;
-	}
+    @Override
+    public void appendHoverText(ItemStack stack, Level worldIn, List<Component> tooltip, TooltipFlag flag) {
+        if (stack.getCapability(DURABILITY).isPresent()) {
+            stack.getCapability(DURABILITY).ifPresent(cap -> {
+                if (cap.isInfinite()) {
+                    tooltip.add(Component.translatable(LangUtil.tooltip("cap.durability.amount.infinite")));
+                } else {
+                    tooltip.add(Component.translatable(
+                        LangUtil.tooltip("cap.durability.amount"),
+                        cap.durability(stack.getItem()) - stack.getDamageValue(),
+                        cap.durability(stack.getItem())
+                    ));
+                }
+            });
+        } else {
+            tooltip.add(Component.translatable(
+                LangUtil.tooltip("cap.durability.amount"),
+                "whaat",
+                getDurability()
+            ));
+        }
 
-	/**
-	 * 
-	 * @return
-	 */
-	public boolean isBreakable() {
-		return breakable;
-	}
+        tooltip.add(Component.translatable(LangUtil.tooltip("key_lock.rarity"),
+                ChatFormatting.BLUE + Component.translatable(getRarity().getValue().toLowerCase()).getString().toUpperCase()));
+        tooltip.add(Component.translatable(LangUtil.tooltip("key_lock.category"),
+                ChatFormatting.GOLD + Component.translatable(getCategory().toString().toLowerCase()).getString().toUpperCase()));
 
-	/**
-	 * 
-	 * @param breakable
-	 */
-	public KeyItem setBreakable(boolean breakable) {
-		this.breakable = breakable;
-		return this;
-	}
+        LangUtil.appendAdvancedHoverText(tooltip, tt -> {
+            MutableComponent breakableComp;
+            if (isBreakable()) {
+                breakableComp = Component.translatable(LangUtil.tooltip("boolean.yes")).withStyle(ChatFormatting.DARK_RED);
+            } else {
+                breakableComp = Component.translatable(LangUtil.tooltip("boolean.no")).withStyle(ChatFormatting.GREEN);
+            }
+            tooltip.add(Component.translatable(LangUtil.tooltip("key_lock.breakable"), breakableComp));
 
-	public KeyItem addFitsLock(Predicate<LockItem> p) {
-		if (fitsLock == null) {
-			fitsLock = new ArrayList<>();
-		}
-		fitsLock.add(p);
-		return this;
-	}
+            MutableComponent craftableComp;
+            if (isCraftable()) {
+                craftableComp = Component.translatable(LangUtil.tooltip("boolean.yes")).withStyle(ChatFormatting.GREEN);
+            } else {
+                craftableComp = Component.translatable(LangUtil.tooltip("boolean.no")).withStyle(ChatFormatting.DARK_RED);
+            }
+            tooltip.add(Component.translatable(LangUtil.tooltip("key_lock.craftable"), craftableComp));
 
-	public List<Predicate<LockItem>> getFitsLock() {
-		return this.fitsLock;
-	}
+            appendHoverSpecials(stack, worldIn, tooltip, flag);
+            appendHoverExtras(stack, worldIn, tooltip, flag);
+        });
+        appendCurse(stack, tooltip);
+    }
 
-	public KeyItem addBreaksLock(Predicate<LockItem> p) {
-		if (breaksLock == null) {
-			breaksLock = new ArrayList<>();
-		}
-		breaksLock.add(p);
-		return this;
-	}
-	
-	public List<Predicate<LockItem>> getBreaksLock() {
-		return breaksLock;
-	}
-	
-	/**
-	 * @return the successProbability
-	 */
-	public double getSuccessProbability() {
-		return successProbability;
-	}
+    public void appendCurse(ItemStack stack, List<Component> tooltip) {}
 
-	/**
-	 * @param successProbability the successProbability to set
-	 */
-	public KeyItem setSuccessProbability(double successProbability) {
-		this.successProbability = successProbability;
-		return this;
-	}
+    public void appendHoverSpecials(ItemStack stack, Level worldIn, List<Component> tooltip, TooltipFlag flag) {}
+    public void appendHoverExtras(ItemStack stack, Level worldIn, List<Component> tooltip, TooltipFlag flag) {}
 
-	/**
-	 * Convenience method
-	 * @return the damageable
-	 */
-	public boolean isDamageable(ItemStack stack) {
-		// ensure that stack != null -some mod is using mixins on this function
-		// and the stack could possibly be null
-		if (stack == null) {
-			return super.isDamageable(stack);
-		}
+    @Override
+    public int getBarWidth(ItemStack stack) {
+        return stack.getCapability(DURABILITY).map(handler -> {
+            float ratio = 13.0F - (float) stack.getDamageValue() * 13.0F / (float) handler.durability(stack.getItem());
+            return Math.round(ratio);
+        }).orElse(Math.round(13.0F - (float) stack.getDamageValue() * 13.0F / (float) this.getDurability()));
+    }
 
-		IDurabilityHandler handler = stack.getCapability(TreasureCapabilities.DURABILITY).map(h -> h).orElse(null);
-		if (handler != null) {
-			return !handler.isInfinite();
-		}
-		return true;
-	}
+    @Override
+    public int getBarColor(ItemStack stack) {
+        float stackMaxDamage = stack.getCapability(DURABILITY)
+                                    .map(handler -> (float) handler.durability(stack.getItem()))
+                                    .orElse((float) this.getDurability());
+        float f = Math.max(0.0F, (stackMaxDamage - stack.getDamageValue()) / stackMaxDamage);
+        return Mth.hsvToRgb(f / 3.0F, 1.0F, 1.0F);
+    }
 
-//	public void setDamageable(boolean damageable) {
-//		this.damageable = damageable;
-//	}
+    @Override
+    public boolean isValidRepairItem(ItemStack itemToRepair, ItemStack resourceItem) {
+        return resourceItem.getItem() == this || super.isValidRepairItem(itemToRepair, resourceItem);
+    }
 
+    @Override
+    public InteractionResult useOn(UseOnContext context) {
+        if (WorldInfo.isClientSide(context.getLevel())) {
+            return InteractionResult.FAIL;
+        }
 
-	public int getDurability() {
-		return durability;
-	}
+        BlockPos chestPos = context.getClickedPos();
+        BlockState state = context.getLevel().getBlockState(chestPos);
+        Block block = state.getBlock();
 
-	public void setDurability(int durability) {
-		this.durability = durability;
-	}
+        if (block instanceof ITreasureChestBlockProxy) {
+            chestPos = ((ITreasureChestBlockProxy) block).getChestPos(chestPos);
+            state = context.getLevel().getBlockState(chestPos);
+            block = state.getBlock();
+        }
+
+        if (block instanceof AbstractTreasureChestBlock) {
+            BlockEntity blockEntity = context.getLevel().getBlockEntity(chestPos);
+            if (blockEntity == null || !(blockEntity instanceof ITreasureChestBlockEntity)) {
+                Treasure.LOGGER.warn("null or incorrect blockEntity");
+                return InteractionResult.FAIL;
+            }
+            ITreasureChestBlockEntity chestBlockEntity = (ITreasureChestBlockEntity) blockEntity;
+
+            if (!chestBlockEntity.hasLocks()) {
+                return InteractionResult.SUCCESS;
+            }
+
+            try {
+                ItemStack heldItemStack = context.getPlayer().getItemInHand(context.getHand());
+                boolean breakKey = true;
+                boolean fitsLock = false;
+                LockState lockState = null;
+                boolean isKeyBroken = false;
+
+                lockState = fitsFirstLock(chestBlockEntity.getLockStates());
+                if (lockState != null) {
+                    fitsLock = true;
+                }
+
+                if (fitsLock && unlock(lockState.getLock())) {
+                    doUnlock(context, chestBlockEntity, lockState);
+                    if (!state.getValue(AbstractTreasureChestBlock.DISCOVERED)) {
+                        chestBlockEntity = ((AbstractTreasureChestBlock) block).discovered(
+                            (AbstractTreasureChestBlockEntity) chestBlockEntity,
+                            state,
+                            context.getLevel(),
+                            chestPos,
+                            context.getPlayer()
+                        );
+                    }
+                    chestBlockEntity.sendUpdates();
+                    breakKey = false;
+                }
+
+                IDurabilityHandler cap = heldItemStack.getCapability(DURABILITY).orElseThrow(IllegalStateException::new);
+                if (breakKey) {
+                    Treasure.LOGGER.debug("breakKey -> {}", breakKey);
+                    if (!context.getPlayer().isCreative() &&
+                        (isBreakable() || anyLockBreaksKey(chestBlockEntity.getLockStates(), this)) &&
+                        Config.SERVER.keysAndLocks.enableKeyBreaks.get()) {
+
+                        Treasure.LOGGER.debug("is breakable -> {}", isBreakable());
+                        int durability = getDurability();
+                        int damage = heldItemStack.getDamageValue() + (durability - (heldItemStack.getDamageValue() % durability));
+                        heldItemStack.setDamageValue(damage);
+                        Treasure.LOGGER.debug("damaging key -> {}", heldItemStack.getDamageValue());
+                        if (heldItemStack.getDamageValue() >= cap.durability(heldItemStack.getItem())) {
+                            heldItemStack.shrink(1);
+                        }
+                        doKeyBreakEffects(context.getLevel(), context.getPlayer(), chestPos);
+                        isKeyBroken = true;
+                    } else if (!fitsLock) {
+                        doKeyNotFitEffects(context.getLevel(), context.getPlayer(), chestPos);
+                    } else {
+                        doKeyUnableToUnlockEffects(context.getLevel(), context.getPlayer(), chestPos);
+                    }
+                }
+
+                if (!context.getPlayer().isCreative() && isDamageable(heldItemStack) && !isKeyBroken) {
+                    heldItemStack.setDamageValue(heldItemStack.getDamageValue() + 1);
+                    Treasure.LOGGER.debug("damaging key -> {}", heldItemStack.getDamageValue());
+                    if (heldItemStack.getDamageValue() >= cap.durability(heldItemStack.getItem())) {
+                        heldItemStack.shrink(1);
+                    }
+                }
+            } catch (Exception e) {
+                Treasure.LOGGER.error("error: ", e);
+            }
+        }
+        return super.useOn(context);
+    }
+
+    public void doUnlock(UseOnContext context, ITreasureChestBlockEntity chestTileEntity, LockState lockState) {
+        LockItem lock = lockState.getLock();
+        lock.doUnlock(context.getLevel(), context.getPlayer(), context.getClickedPos(), lockState);
+
+        if (!breaksLock(lock)) {
+            lock.dropLock(context.getLevel(), context.getClickedPos());
+        }
+    }
+
+    public boolean fitsLock(LockItem lockItem) {
+        if (getFitsLock() == null || getFitsLock().isEmpty()) {
+            return false;
+        }
+        for (Predicate<LockItem> p : this.getFitsLock()) {
+            boolean result = p.test(lockItem);
+            if (!result) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public LockState fitsFirstLock(List<LockState> lockStates) {
+        LockState lockState = null;
+        for (LockState ls : lockStates) {
+            if (ls.getLock() != null) {
+                lockState = ls;
+                if (lockState.getLock().acceptsKey(this) || fitsLock(lockState.getLock())) {
+                    return ls;
+                }
+            }
+        }
+        return null;
+    }
+
+    public boolean unlock(LockItem lockItem) {
+        if (lockItem.acceptsKey(this) || fitsLock(lockItem)) {
+            Treasure.LOGGER.debug("lock -> {} accepts key -> {}", ModUtil.getName(lockItem), ModUtil.getName(this));
+            if (RandomHelper.checkProbability(new Random(), this.getSuccessProbability())) {
+                Treasure.LOGGER.debug("unlock attempt met probability");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean breaksLock(LockItem lockItem) {
+        if (getBreaksLock() == null || getBreaksLock().isEmpty()) {
+            return false;
+        }
+        for (Predicate<LockItem> p : this.getBreaksLock()) {
+            boolean result = p.test(lockItem);
+            if (!result) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean anyLockBreaksKey(List<LockState> lockStates, KeyItem key) {
+        for (LockState ls : lockStates) {
+            if (ls.getLock() != null && ls.getLock().breaksKey(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public IRarity getRarity() {
+        IRarity rarity = KeyLockRegistry.getRarityByKey(this);
+        if (rarity == null) {
+            return Rarity.NONE;
+        }
+        return rarity;
+    }
+
+    public boolean isCraftable() {
+        return craftable;
+    }
+
+    public KeyItem setCraftable(boolean craftable) {
+        this.craftable = craftable;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "KeyItem [rarity=" + getRarity() + ", craftable=" + craftable + "]";
+    }
+
+    public KeyLockCategory getCategory() {
+        return category;
+    }
+
+    public KeyItem setCategory(KeyLockCategory category) {
+        this.category = category;
+        return this;
+    }
+
+    public boolean isBreakable() {
+        return breakable;
+    }
+
+    public KeyItem setBreakable(boolean breakable) {
+        this.breakable = breakable;
+        return this;
+    }
+
+    public KeyItem addFitsLock(Predicate<LockItem> p) {
+        if (fitsLock == null) {
+            fitsLock = new ArrayList<>();
+        }
+        fitsLock.add(p);
+        return this;
+    }
+
+    public List<Predicate<LockItem>> getFitsLock() {
+        return this.fitsLock;
+    }
+
+    public KeyItem addBreaksLock(Predicate<LockItem> p) {
+        if (breaksLock == null) {
+            breaksLock = new ArrayList<>();
+        }
+        breaksLock.add(p);
+        return this;
+    }
+
+    public List<Predicate<LockItem>> getBreaksLock() {
+        return breaksLock;
+    }
+
+    public double getSuccessProbability() {
+        return successProbability;
+    }
+
+    public KeyItem setSuccessProbability(double successProbability) {
+        this.successProbability = successProbability;
+        return this;
+    }
+
+    /**
+     * Convenience method
+     */
+    public boolean isDamageable(ItemStack stack) {
+        if (stack == null) {
+            return super.isDamageable(stack);
+        }
+        IDurabilityHandler handler = stack.getCapability(TreasureCapabilities.DURABILITY).orElse(null);
+        if (handler != null) {
+            return !handler.isInfinite();
+        }
+        return true;
+    }
+
+    public int getDurability() {
+        return durability;
+    }
+
+    public void setDurability(int durability) {
+        this.durability = durability;
+    }
 }
+


### PR DESCRIPTION
When the server attempts to sync a Treasure² KeyItem (for example by opening an inventory or Refined Storage grid containing one), it crashes with either an ArrayIndexOutOfBoundsException or a NullPointerException originating in KeyItem.getShareTag(...). This disconnects all players holding that key.

Treasure²	1.20.1‑3.11.1
ModernFix	Default (mixin.perf.nbt_memory_usage = true) Lithium	0.11.2